### PR TITLE
Reuse existing stub video asset after Transcoder has exited early

### DIFF
--- a/app/easyaccess.py
+++ b/app/easyaccess.py
@@ -32,7 +32,7 @@ from lib.fixity import fixity_move, generate_file_md5, post_move_filename
 from lib.formatting import seconds_to_hms
 from lib.s3 import upload_to_s3
 from lib.slack import post_slack_message
-from lib.xos import update_xos_with_final_video, update_xos_with_stub_video
+from lib.xos import update_xos_with_final_video, get_or_create_xos_stub_video
 
 logging.basicConfig(format='%(asctime)s: %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S', level=logging.INFO)
 
@@ -168,13 +168,13 @@ def main():
 
     # UPDATE XOS WITH STUB VIDEO
     try:
-        logging.info("Updating XOS with stub video...")
-        asset_id = update_xos_with_stub_video({
+        logging.info("Getting or creating XOS stub video...")
+        asset_id = get_or_create_xos_stub_video({
             'title': master_filename+" NOT UPLOADED",
-            'master_metadata': json.dumps(master_metadata, default=str)
+            'master_metadata': master_metadata
         })
         logging.info("Stub video django ID: %s" % asset_id)
-        logging.info("Updating XOS with stub video... DONE\n")
+        logging.info("Getting or creating XOS stub video... DONE\n")
     except Exception as e:
         return post_slack_exception("Couldn't update XOS: %s" % e)
 

--- a/app/lib/ffmpeg.py
+++ b/app/lib/ffmpeg.py
@@ -123,7 +123,7 @@ def get_video_metadata(video_location):
 
     return {
         'mime_type': VIDEO_MIME_TYPES.get(ext, None),
-        'creation_datetime': creation_datetime,
+        'creation_datetime': str(creation_datetime),
         'file_size_bytes': file_metadata['file_size_bytes'],
 
         'duration_secs': float(m['format'].get('duration', 0.0)),

--- a/app/lib/xos.py
+++ b/app/lib/xos.py
@@ -9,9 +9,11 @@ def update_xos_with_stub_video(video_data):
     xos_video_endpoint = f'{XOS_API_ENDPOINT}assets/'
     headers = {'Authorization': 'Token ' + XOS_AUTH_TOKEN}
     response = requests.post(xos_video_endpoint, json=video_data, headers=headers)
+    response.raise_for_status()
     return response.json()['id']
 
 def update_xos_with_final_video(asset_id, video_data):
     xos_video_endpoint = f'{XOS_API_ENDPOINT}assets/{asset_id}/'
     headers = {'Authorization': 'Token ' + XOS_AUTH_TOKEN}
     response = requests.patch(xos_video_endpoint, json=video_data, headers=headers)
+    response.raise_for_status()

--- a/app/lib/xos.py
+++ b/app/lib/xos.py
@@ -6,6 +6,10 @@ XOS_AUTH_TOKEN = os.environ['XOS_AUTH_TOKEN']
 XOS_API_ENDPOINT = os.environ['XOS_API_ENDPOINT']
 
 def get_or_create_xos_stub_video(video_data):
+    """
+    Creates and returns the ID of a stub video with keys and values from video_data.
+    If one already exists due to a previously failed transcoding, just returns its ID.
+    """
     xos_video_endpoint = f'{XOS_API_ENDPOINT}assets/'
     headers = {'Authorization': 'Token ' + XOS_AUTH_TOKEN}
 
@@ -20,6 +24,9 @@ def get_or_create_xos_stub_video(video_data):
     return response.json()['id']
 
 def update_xos_with_final_video(asset_id, video_data):
+    """
+    Update the specified asset with keys and values from video_data
+    """
     xos_video_endpoint = f'{XOS_API_ENDPOINT}assets/{asset_id}/'
     headers = {'Authorization': 'Token ' + XOS_AUTH_TOKEN}
     response = requests.patch(xos_video_endpoint, json=video_data, headers=headers)

--- a/app/lib/xos.py
+++ b/app/lib/xos.py
@@ -5,9 +5,16 @@ import requests
 XOS_AUTH_TOKEN = os.environ['XOS_AUTH_TOKEN']
 XOS_API_ENDPOINT = os.environ['XOS_API_ENDPOINT']
 
-def update_xos_with_stub_video(video_data):
+def get_or_create_xos_stub_video(video_data):
     xos_video_endpoint = f'{XOS_API_ENDPOINT}assets/'
     headers = {'Authorization': 'Token ' + XOS_AUTH_TOKEN}
+
+    get_response = requests.get(xos_video_endpoint+'?title_contains=NOT%20UPLOADED&checksum='+video_data['master_metadata']['checksum'], headers=headers)
+    get_response.raise_for_status()
+    get_response_json = get_response.json()
+    if get_response_json['count'] == 1:
+        return get_response_json['results'][0]['id']
+
     response = requests.post(xos_video_endpoint, json=video_data, headers=headers)
     response.raise_for_status()
     return response.json()['id']

--- a/dev.tmpl.env
+++ b/dev.tmpl.env
@@ -16,6 +16,7 @@ S3_SECRET_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 S3_LOCATION=stevetest
 
 XOS_API_ENDPOINT=http://<your ip>:8000/api
+# XOS_AUTH_TOKEN token's user requires staff privileges for PATCH to /api/assets
 XOS_AUTH_TOKEN=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 
 # If not using Docker and SMB, set local directories to use


### PR DESCRIPTION
*Partially resolves ACMILabs/xos#1426*

When the transcoder reruns after an early exit, reuse the existing stub, by looking for an asset with "NOT UPLOADED" in title, and a matching checksum in the master_metadata.
Requires "#1426 adds title_contains and checksum query params to asset API endpoint" in XOS.

Testing:
0. Check out the add/1426-reuse-stub branch in XOS
1. Run the transcoder, stopping it while ffmpeg is running.
2. Rerun the transcoder and check the logs to make sure that the "Stub video django ID" is reused.